### PR TITLE
Version 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ services:
       - vol-app:/var/www/html
     environment: 
       - TZ=
-      - LB_DB_HOST=lb-db
+      - LB_DB_HOST=db
       - LB_DB_NAME=librebooking
       - LB_INSTALL_PWD=
       - LB_DB_USER=lb_user
@@ -116,7 +116,7 @@ services:
       - vol-app:/var/www/html
     environment: 
       - TZ=
-      - LB_DB_HOST=lb-db
+      - LB_DB_HOST=db
       - LB_DB_NAME=librebooking
       - LB_INSTALL_PWD_FILE=/run/secrets/lb_install_pwd
       - LB_DB_USER=lb_user
@@ -220,7 +220,7 @@ services:
       - vol-app:/var/www/html
     environment: 
       - TZ=
-      - LB_DB_HOST=lb-db
+      - LB_DB_HOST=db
       - LB_DB_NAME=librebooking
       - LB_INSTALL_PWD=
       - LB_DB_USER=lb_user

--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ secrets:
 
 Then run the following commands:
 ```
-echo 'your_Mariadb_root_password' > db_root_pwd.txt;
-echo 'your_Mariadb_user_password' > db_user_pwd.txt;
-echo 'your_Librebooking_installation_password' > lb_install_pwd.txt;
+echo -n 'your_Mariadb_root_password' > db_root_pwd.txt;
+echo -n 'your_Mariadb_user_password' > db_user_pwd.txt;
+echo -n 'your_Librebooking_installation_password' > lb_install_pwd.txt;
 docker-compose up --detach
 ```
 


### PR DESCRIPTION
README.md:
- Fix docker-compose.yml examples by setting `LB_DB_HOST=db`
- Fix the bash instructions by using the `-n` argument with the echo command