### PR TITLE
Fix permissions for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.opencontainers.image.authors="colisee@hotmail.com"
 COPY --chmod=755 bin /usr/local/bin/
 
 # Create cron jobs
-COPY --chown=www-data:root --chmod=0775 lb-jobs-cron /config/
+COPY --chown=www-data:www-data --chmod=0755 lb-jobs-cron /config/
 
 # Copy composer
 COPY --from=comp /usr/bin/composer /usr/bin/composer
@@ -89,8 +89,15 @@ RUN set -ex; \
     if ! [ -d /var/www/html/tpl_c ]; then \
       mkdir /var/www/html/tpl_c; \
     fi; \
-    chown --recursive www-data:root /var/www/html; \
-    chmod --recursive g+rwx /var/www/html
+    mkdir /var/www/html/Web/uploads/reservation
+
+RUN set -ex; \
+    chown www-data:root /var/www/html/tpl_c; \
+    chmod g+rwx /var/www/html/tpl_c; \
+    chgrp root /var/www/html/config /var/www/html/Web/uploads/images \
+          /var/www/html/Web/uploads/reservation; \
+    chmod g+rwx /var/www/html/config /var/www/html/Web/uploads/images \
+          /var/www/html/Web/uploads/reservation
 
 # Environment
 USER       www-data


### PR DESCRIPTION

Hi,

considering the OpenShift case, where uid is random, and gid is root.

I modified this a bit.

1. First of all, the cron jobs don't need to be writeable in container, so I removed write from group root.

2. I removed recursive group write persmission for the all html files. It's too wide permission.

3. I add upload reservations dir for the reservation images so that we can give proper permissions to it.

4. I add write permission for root group for cache (tpl_c), config dir where the config link will be done, and also image uploads for generic and reservation resources.

I tested this by building it with podman:

`podman build --cache-ttl=0 . -t librebooking-ocp:v4.1.0 --build-arg APP_GH_REF=v4.1.0`

both with x86_64 and arm64.

I also tested the image both with podman on x86_64 Fedora 43, and microshift on rapsberrypi 4 for arm openshift. Seems to work fine.
