### PR TITLE
chore: update references to point at current Librebooking URL

### DIFF
--- a/.github/workflows/build_on_request.yml
+++ b/.github/workflows/build_on_request.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       appGitRefs:
         required: true
-        description: 'Librebooking/app version'
+        description: 'Librebooking/librebooking version'
         default: 'develop'
       imgBuild:
         required: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What is librebooking
 
-[Librebooking](https://github.com/librebooking/app) is a simple powerful
+[Librebooking](https://github.com/Librebooking/librebooking) is a simple powerful
 scheduling solution for any organization, forked from
 [Booked](https://www.bookedscheduler.com/).
 

--- a/RUN.md
+++ b/RUN.md
@@ -6,7 +6,7 @@ It needs to be linked to a running MariaDB database container.
 ## Environment variables
 
 From version-3, this docker image makes full usage of the
-[environment variables override](https://github.com/LibreBooking/app/blob/develop/docs/source/BASIC-CONFIGURATION.rst).
+[environment variables override](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/BASIC-CONFIGURATION.rst).
 
 ### Required variables
 
@@ -45,7 +45,7 @@ For instance:
 
 Several services in librebooking such as reminder emails require a job
 scheduler. For a full list of background jobs, checkout the
-[wiki](https://github.com/LibreBooking/app/wiki/Background-jobs)
+[wiki](https://github.com/LibreBooking/librebooking/wiki/Background-jobs)
 
 The background jobs can either be handled by the:
 


### PR DESCRIPTION
Update references that were using "Librebooking/app" to point to the new location at "Librebooking/librebooking"

As the GitHub repository was renamed to:
https://github.com/LibreBooking/librebooking