### PR TITLE
fix: Allow locale writing in OpenShift kube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ RUN set -ex; \
     chown --recursive www-data:root /var/log/librebooking; \
     chmod --recursive g+rwx /var/log/librebooking; \
     touch /usr/local/etc/php/conf.d/librebooking.ini; \
-    chown www-data:root /usr/local/etc/php/conf.d/librebooking.ini; \
     sed \
       -i /etc/apache2/ports.conf \
       -e 's/Listen 80/Listen 8080/' \
@@ -96,12 +95,14 @@ RUN set -ex; \
       /var/www/html/config \
       /var/www/html/tpl_c \
       /var/www/html/Web/uploads/images \
-      /var/www/html/Web/uploads/reservation; \
+      /var/www/html/Web/uploads/reservation \
+      /usr/local/etc/php/conf.d/librebooking.ini; \
     chmod g+rwx \
       /var/www/html/config \
       /var/www/html/tpl_c \
       /var/www/html/Web/uploads/images \
-      /var/www/html/Web/uploads/reservation; \
+      /var/www/html/Web/uploads/reservation \
+      /usr/local/etc/php/conf.d/librebooking.ini; \
     chown --recursive www-data:root \
       /var/www/html/plugins; \
     chmod --recursive g+rwx \


### PR DESCRIPTION
There is permission error in OpenShift if local timezone is configured in env. Entrypoint tries to write `$LB_DEFAULT_TIMEZONE` to librebooking.ini which gets denied.

```
+ '[' -f /usr/share/zoneinfo/Europe/Helsinki ']'
+ INI_FILE=/usr/local/etc/php/conf.d/librebooking.ini
+ echo '[Date]'
/usr/local/bin/entrypoint.sh: line 95: /usr/local/etc/php/conf.d/librebooking.ini: Permission denied
```
