### PR TITLE
fix(build_sys): install the `intl` PHP extension

### DIFF
--- a/bin/build_sys.sh
+++ b/bin/build_sys.sh
@@ -15,6 +15,7 @@ apt-get upgrade --yes
 apt-get install --yes --no-install-recommends \
   libjpeg-dev \
   libldap-dev \
+  libicu-dev \
   libpng-dev \
   libfreetype6-dev \
   unzip
@@ -46,7 +47,7 @@ cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 touch /usr/local/etc/php/conf.d/librebooking.ini
 
 docker-php-ext-configure gd --with-jpeg --with-freetype
-docker-php-ext-install mysqli gd ldap
+docker-php-ext-install mysqli gd ldap intl
 pecl install timezonedb
 docker-php-ext-enable timezonedb
 


### PR DESCRIPTION
Upstream made the `intl` PHP extension a requirement[1]. Update the build script to install it.

1. In commit ccd90236dc64645f3889e4efb684493dde68c949 in LibreBooking: https://github.com/LibreBooking/librebooking/commit/ccd90236dc64645f3889e4efb684493dde68c949